### PR TITLE
Fix reference index check in Genos annotation script

### DIFF
--- a/annotate/genos_annotate.sh
+++ b/annotate/genos_annotate.sh
@@ -92,8 +92,8 @@ s/INFO$/INFO\tFORMAT\tsample-id/
 ' | bgzip -c > data/All_GRCh37_reference_multi.vcf.gz
 fi;
 
-# Perhaps check timestamp? Check broken on purpose now.
-if [ ! -e data/All_GRCh37_${SAMPLE}_multi.vcf.gz.tbi.not ];
+# Perhaps check timestamp? Re-run only if the index is missing.
+if [ ! -e data/All_GRCh37_${SAMPLE}_multi.vcf.gz.tbi ];
 then
   echo "## Renaming sample in reference file..."
   echo "$SAMPLENAME" > ${SAMPLE}_samplename


### PR DESCRIPTION
## Summary
- Correct the conditional check for `All_GRCh37_*_multi.vcf.gz` index file in `genos_annotate.sh`
- Prevent unnecessary reheadering when the tabix index already exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68984c6315c88332a5be0c45e709c7dc