### PR TITLE
Avoid infinite loop in dbSNP change script

### DIFF
--- a/util/dbSNP_changes.pl
+++ b/util/dbSNP_changes.pl
@@ -15,7 +15,27 @@ my ( $oldrow, $newrow, $oldchr );
 # Skip header, which according to spec can only be at beginning. We don't care about content right now.
 while ( defined( $oldrow = <$old> ) && ( substr( $oldrow, 0, 1 ) eq '#' ) ) { }
 while ( defined( $newrow = <$new> ) && ( substr( $newrow, 0, 1 ) eq '#' ) ) { }
-while (1) {
+MAIN: while ( defined $oldrow || defined $newrow ) {
+    if ( !defined $oldrow ) {
+        my @newcols1 = split( "\t", $newrow );
+        if ( !defined($oldchr) || !( $oldchr eq $newcols1[0] ) ) {
+            print("$newcols1[0]\n");
+            $oldchr = $newcols1[0];
+        }
+        print "+" . join( "\t", @newcols1[1..4] ) . "\n";
+        $newrow = <$new>;
+        next;
+    }
+    if ( !defined $newrow ) {
+        my @oldcols1 = split( "\t", $oldrow );
+        if ( !defined($oldchr) || !( $oldchr eq $oldcols1[0] ) ) {
+            print("$oldcols1[0]\n");
+            $oldchr = $oldcols1[0];
+        }
+        print "-" . $oldcols1[2] . "\n";
+        $oldrow = <$old>;
+        next;
+    }
 
     # Process single genomic location at a time.
     my @oldrows  = ($oldrow);
@@ -31,13 +51,13 @@ while (1) {
     if ( !( $oldcols1[0] eq $newcols1[0] ) || ( $oldcols1[1] <= $newcols1[1] ) )
     {
         $oldrow = <$old>;
-        my @oldcols = split( "\t", $oldrow );
-        while (( $oldcols1[0] eq $oldcols[0] )
+        my @oldcols = split( "\t", $oldrow // '' );
+        while ( @oldcols && ( $oldcols1[0] eq $oldcols[0] )
             && ( $oldcols1[1] eq $oldcols[1] ) )
         {
             push( @oldrows, $oldrow );
             $oldrow = <$old>;
-            @oldcols = split( "\t", $oldrow );
+            @oldcols = split( "\t", $oldrow // '' );
         }
 
         @oldrows = sort {
@@ -54,13 +74,13 @@ while (1) {
     if ( !( $oldcols1[0] eq $newcols1[0] ) || ( $oldcols1[1] >= $newcols1[1] ) )
     {
         $newrow = <$new>;
-        my @newcols = split( "\t", $newrow );
-        while (( $newcols1[0] eq $newcols[0] )
+        my @newcols = split( "\t", $newrow // '' );
+        while ( @newcols && ( $newcols1[0] eq $newcols[0] )
             && ( $newcols1[1] eq $newcols[1] ) )
         {
             push( @newrows, $newrow );
             $newrow = <$new>;
-            @newcols = split( "\t", $newrow );
+            @newcols = split( "\t", $newrow // '' );
         }
 
         @newrows = sort {


### PR DESCRIPTION
## Summary
- Prevent `dbSNP_changes.pl` from looping endlessly when one input file reaches EOF
- Safely handle remaining records so new or removed variants are reported

## Testing
- `perl -c util/dbSNP_changes.pl`
- `perl util/dbSNP_changes.pl old.txt new.txt`

------
https://chatgpt.com/codex/tasks/task_e_68984c6315c88332a5be0c45e709c7dc