### PR TITLE
Handle absent zero insert sizes in CIGAR histogram script

### DIFF
--- a/util/cigar-hist.pl
+++ b/util/cigar-hist.pl
@@ -78,7 +78,8 @@ while (<STDIN>) {
 }
 
 # Unmatched pairs both have insert size 0, so we need to halve it.
-$insert[0]=$insert[0]/2;
+# Guard against undefined value when no insert size 0 entries exist.
+$insert[0] = $insert[0] ? $insert[0] / 2 : 0;
 
 # Not pass by reference for simplicity
 sub histogram {


### PR DESCRIPTION
## Summary
- avoid dividing undefined array element when no zero insert sizes are present in `cigar-hist.pl`

## Testing
- `perl -c util/cigar-hist.pl`
- `printf 'r1\t0\tchr1\t1\t255\t10M\t*\t0\t100\tACGT\t*\tMD:Z:10\n' | perl util/cigar-hist.pl >/tmp/out.txt`
- `cat /tmp/out.txt | head`


------
https://chatgpt.com/codex/tasks/task_e_689874479eb88332b48b66e55b574780